### PR TITLE
Use `Domain` selector instead of `Host` to block subdomains

### DIFF
--- a/cf_gateway_rule_create.js
+++ b/cf_gateway_rule_create.js
@@ -30,7 +30,7 @@ async function getZeroTrustLists() {
 
     // Build the wirefilter expression
     for (const list of filtered_lists) {
-        wirefilter_expression += `dns.fqdn in \$${list.id} or `;
+        wirefilter_expression += `any(dns.domains[*] in \$${list.id}) or `;
     }
     // Remove the trailing ' or '
     if (wirefilter_expression.endsWith(' or ')) {


### PR DESCRIPTION
I think this is a good idea since popular blocklists are available in wildcard domains format. We can take advantage of it to deal with the 300K domains limit. This is also the behaviour of NextDNS.