### PR TITLE
Fix cases where the lists are empty string

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -32,11 +32,13 @@ export const LIST_TYPE = {
   BLOCKLIST: "blocklist",
 };
 
-export const USER_DEFINED_ALLOWLIST_URLS =
-  process.env.ALLOWLIST_URLS?.split("\n");
+export const USER_DEFINED_ALLOWLIST_URLS = process.env.ALLOWLIST_URLS
+  ? process.env.ALLOWLIST_URLS.split("\n")
+  : undefined;
 
-export const USER_DEFINED_BLOCKLIST_URLS =
-  process.env.BLOCKLIST_URLS?.split("\n");
+export const USER_DEFINED_BLOCKLIST_URLS = process.env.BLOCKLIST_URLS
+  ? process.env.BLOCKLIST_URLS.split("\n")
+  : undefined;
 
 export const RECOMMENDED_ALLOWLIST_URLS = [
   "https://raw.githubusercontent.com/im-sm/Pi-hole-Torrent-Blocklist/main/all-torrent-trackres.txt",


### PR DESCRIPTION
The workflow file interprets the variables as empty string when they are not defined causing the downloadFiles function to fail. Please merge into `v1` soon as well.

@mrrfv 