### PR TITLE
Fix `node-fetch` vs. `fetch` compatibility

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,7 @@
 import { once } from "events";
-import { createReadStream, createWriteStream } from "fs";
+import { ReadStream, createReadStream, createWriteStream } from "fs";
 import { basename } from "path";
 import { createInterface } from "readline";
-import { WritableStream } from "stream/web";
 
 if (!globalThis.fetch) {
   globalThis.fetch = (await import("node-fetch")).default;
@@ -58,19 +57,19 @@ export const isComment = (value) =>
  */
 export const downloadFiles = async (filePath, urls) => {
   const writeStream = createWriteStream(filePath, { flags: "a" });
-  const writableStream = new WritableStream({
-    write(chunk) {
-      writeStream.write(chunk);
-    },
-  });
   const responses = await Promise.all(urls.map((url) => fetch(url)));
 
   for (const response of responses) {
-    await response.body?.pipeTo(writableStream, { preventClose: true });
-    writeStream.write("\n");
-  }
+    const readable = ReadStream.from(response.body, {
+      autoDestroy: true,
+    });
 
-  await writableStream.close();
+    readable.on("end", () => {
+      writeStream.write("\n");
+    });
+
+    readable.pipe(writeStream, { end: false });
+  }
 };
 
 /**


### PR DESCRIPTION
Fixes #31
To note that `node-fetch` returns the response body as `Gunzip` while `fetch` returns it as `ReadableStream`