### PR TITLE
Fix domain validation

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,9 @@ if (!globalThis.fetch) {
  * @param {string} value The value to be checked.
  */
 export const isValidDomain = (value) =>
-  /^(?!-)[A-Za-z0-9-]+([\-\.]{1}[a-z0-9]+)*\.[A-Za-z]{2,6}$/.test(value);
+  /(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]/.test(
+    value
+  );
 
 /**
  * Extracts all subdomains from a domain including itself.


### PR DESCRIPTION
Previous regex missed a lot of domains. Can be tested with a lone blocklist with a large number of entries such as HaGeZi Pro.