### PR TITLE
Assign contents write permission for workflow

### DIFF
--- a/auto_update_github_action.yml
+++ b/auto_update_github_action.yml
@@ -17,6 +17,8 @@ env:
 
 jobs:
   cgps:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This permission is required for `keepalive-workflow` to create a commit but it is not assigned by default.

![image](https://github.com/mrrfv/cloudflare-gateway-pihole-scripts/assets/5486625/a0eb84b7-0ee0-4a1d-8a2e-c9fee9fce493)

Details
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-the-default-github_token-permissions
- https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents
- https://docs.github.com/en/rest/git/commits?apiVersion=2022-11-28#create-a-commit