### PR TITLE
Add dry run check for renovate automerging

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -1,0 +1,24 @@
+name: Dry Run Check
+
+on:
+  push:
+    branches:
+      - renovate/**
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.11.1"
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Dry run
+        run: npm run dry


### PR DESCRIPTION
Renovate automerging requires passing status checks so let's add a dry run on renovate branches

https://docs.renovatebot.com/key-concepts/automerge/#absence-of-tests