### PR TITLE
Workflow update

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20.11.1"
+          node-version-file: ".node-version"
 
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4
+        uses: actions/checkout@v4
 
       - name: Install Node.js
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+        uses: actions/setup-node@v4
         with:
           node-version: "20.11.1"
 

--- a/.github/workflows/sync-branch.yml
+++ b/.github/workflows/sync-branch.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4
+        uses: actions/checkout@v4
         with:
           ref: main
-      - uses: connor-baer/action-sync-branch@0298935825bb8194982d322e7730b783a2ed9cd2 # v1.1.0
+      - uses: connor-baer/action-sync-branch@v1.1.0
         with:
           branch: v1
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-branch.yml
+++ b/.github/workflows/sync-branch.yml
@@ -7,10 +7,12 @@ on:
 
 jobs:
   sync-branch:
-    permissions:
-      contents: write
     name: Update v1 branch
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    # Only run on original repository
+    if: ${{ github.repository_id == 635386785 }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/auto_update_github_action.yml
+++ b/auto_update_github_action.yml
@@ -73,4 +73,4 @@ jobs:
           PING_URL: ${{ secrets.PING_URL }}
 
       - name: Keep workflow alive
-        uses: gautamkrishnar/keepalive-workflow@beb86212524e1ae856d1cd80efb44e73bf7daf4a # v2
+        uses: gautamkrishnar/keepalive-workflow@v2

--- a/auto_update_github_action.yml
+++ b/auto_update_github_action.yml
@@ -17,9 +17,6 @@ env:
 
 jobs:
   cgps:
-    permissions:
-      # Required for gautamkrishnar/keepalive-workflow@v2 to work
-      actions: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -74,3 +71,11 @@ jobs:
 
       - name: Keep workflow alive
         uses: gautamkrishnar/keepalive-workflow@v2
+
+  keepalive:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@v2

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,8 @@
     "config:js-app",
     ":automergeBranch",
     ":automergeDigest",
-    ":automergeMinor"
+    ":automergeMinor",
+    ":pinDigestsDisabled"
   ],
   "github-actions": {
     "fileMatch": ["^auto_update_github_action.yml$"]

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices",
+    "config:recommended",
     "config:js-app",
     ":automergeBranch",
     ":automergeDigest",
-    ":automergeMinor",
-    ":pinDigestsDisabled"
+    ":automergeMinor"
   ],
   "github-actions": {
     "fileMatch": ["^auto_update_github_action.yml$"]

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,6 @@
     "config:recommended",
     "config:js-app",
     ":automergeBranch",
-    ":automergeDigest",
     ":automergeMinor"
   ],
   "github-actions": {


### PR DESCRIPTION
1. In my opinion pinning GitHub Action digests is not necessary for this project so disabling it
2. Use `.node-version` file for Dry Run Check action
3. Add condition for sync branch action as it's not needed for forks
4. Move `keepalive-workflow` into a separate job