### PR TITLE
Fix "repository not found" error

### DIFF
--- a/auto_update_github_action.yml
+++ b/auto_update_github_action.yml
@@ -73,6 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: gautamkrishnar/keepalive-workflow@v2


### PR DESCRIPTION
For private repositories based on this [issue](https://github.com/actions/checkout/issues/1555)