### PR TITLE
Clarify the meaning of the request error/ratelimit message

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -124,13 +124,13 @@ const request = async (url, options) => {
       return data;
     } catch (error) {
       attempts++;
-      console.warn(`An error occured while making a web request: "${error}", retrying. Attempt ${attempts} of ${maxAttempts}.`)
+      console.warn(`An error occured while making a web request: "${error}", retrying. Attempt ${attempts} of ${maxAttempts}.\nTHIS IS NORMAL IN MOST CIRCUMSTANCES. Refrain from reporting this as a bug unless the script doesn't automatically recover after several attempts.`);
       if(attempts >= maxAttempts) {
         // Send a message to the Discord webhook if it exists
         await notifyWebhook(`An HTTP error has occurred (${response ? response.status : "unknown status"}) while making a web request. Please check the logs for further details.`);
         throw new Error(`HTTP error! Status: ${response.status} - ${ (data && 'errors' in data) ? data.errors[0].message : data } - ${error}`);
       }
-      await wait(5000);
+      await wait(8000);
     }
   }
 };


### PR DESCRIPTION
Additionally increases the wait time between requests to 8 seconds (from 5).