### PR TITLE
Check in allowlist for parent domains

### DIFF
--- a/cf_list_create.js
+++ b/cf_list_create.js
@@ -97,6 +97,13 @@ await readFile(resolve(`./${blocklistFilename}`), (line, rl) => {
   // because we are blocking all subdomains
   // Example: fourth.third.example.com => ["example.com", "third.example.com", "fourth.third.example.com"]
   for (const item of extractDomain(domain).slice(1)) {
+    // Check for any higher level domain matches in the allowlist
+    if (allowlist.has(item)) {
+      if (DEBUG) console.log(`Found parent domain ${item} in allowlist - Skipping ${domain}`);
+      allowedDomainCount++;
+      return;
+    }
+
     if (!blocklist.has(item)) continue;
 
     // The higher-level domain is already blocked


### PR DESCRIPTION
If the allowlist contains a parent or higher-level domain, skip adding any subdomains of that parent to the blocklist