### PR TITLE
Option to use `allowlist.txt` as the allowlist

### DIFF
--- a/download_lists.js
+++ b/download_lists.js
@@ -17,6 +17,11 @@ const blocklistUrls = USER_DEFINED_BLOCKLIST_URLS || RECOMMENDED_BLOCKLIST_URLS;
 const listType = process.argv[2];
 
 const downloadLists = async (filename, urls) => {
+  if (urls.length === 1 && filename === urls[0]) {
+    console.log(`Skipping download for ${filename}, explicitly using existing file`);
+    return;
+  }
+
   const filePath = resolve(`./${filename}`);
 
   if (existsSync(filePath)) {


### PR DESCRIPTION
If `allowlist.txt` is explicitly set as the `ALLOWLIST_URLS`, skip downloading anything and use the local file