### PR TITLE
Added support for docker and GHCR container building

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ BLOCK_BASED_ON_SNI=0
 # Optional Discord webhook URL to send a message to when a script is done running or if an error occurs.
 # DISCORD_WEBHOOK_URL=
 
-# Optional docker-compose.yml settings
+# Optional settings for the Docker container example (see docker-compose.yml.example)
 # CONTAINER_NAME=cgps
 # IMAGE_TAG=latest
+# CRON_SCHEDULE=0 3 * * 1

--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ BLOCK_BASED_ON_SNI=0
 
 # Optional Discord webhook URL to send a message to when a script is done running or if an error occurs.
 # DISCORD_WEBHOOK_URL=
+
+# Optional docker-compose.yml settings
+# CONTAINER_NAME=cgps
+# IMAGE_TAG=latest

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ BLOCK_BASED_ON_SNI=0
 # DISCORD_WEBHOOK_URL=
 
 # Optional settings for the Docker container example (see docker-compose.yml.example)
+# TZ=UTC
 # CONTAINER_NAME=cgps
 # IMAGE_TAG=latest
 # CRON_SCHEDULE=0 3 * * 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Publish to container registry
 
 on:
+  push:
+    branches:
+      - v*
   release:
     types: [ "published" ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,9 @@ jobs:
       packages: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Get Node Version
         run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
 
@@ -53,6 +56,7 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@v6
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,9 @@ jobs:
       packages: write
 
     steps:
+      - name: Get Node Version
+        run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_ENV
+
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -53,7 +56,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            NODE_VERSION=$(cat .node-version)
+            NODE_VERSION=${{ env.NODE_VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: Publish to container registry
+
+on:
+  release:
+    types: [ "published" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,30 +22,25 @@ jobs:
       packages: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      # Set up BuildKit Docker container builder to be able to build
-      # multi-platform images and export cache
-      # https://github.com/docker/setup-buildx-action
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
-
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Set up BuildKit Docker container builder to be able to build multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -53,10 +48,12 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        uses: docker/build-push-action@v6
         with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            NODE_VERSION=$(cat .node-version)
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM docker.io/node:22.14.0-alpine
+ARG NODE_VERSION
+
+FROM docker.io/node:${NODE_VERSION}-alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /app
 # Add project source to image
 ADD . /app
 
-# Install project dependencies
-RUN npm ci
+# Install project dependencies and set permissions
+RUN npm ci && chmod +x /app/docker-entrypoint.sh
 
 # Run the entrypoint script on container startup
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION
+ARG NODE_VERSION=lts
 
 FROM docker.io/node:${NODE_VERSION}-alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 ADD . /app
 
 # Install project dependencies and set permissions
-RUN npm ci && chmod +x /app/docker-entrypoint.sh
+RUN apk add --no-cache tzdata && npm ci && chmod +x /app/docker-entrypoint.sh
 
 # Run the entrypoint script on container startup
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM docker.io/node:22.14.0-alpine
+
+WORKDIR /app
+
+# Add project source to image
+ADD . /app
+
+# Install project and cron entry
+RUN npm ci && echo "0 3 * * 1 /bin/bash /app/update_filter_lists.sh" | crontab -
+
+# Run the command on container startup
+ENTRYPOINT ["/usr/sbin/crond", "-l", "2", "-f"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /app
 # Add project source to image
 ADD . /app
 
-# Install project and cron entry
-RUN npm ci && echo "0 3 * * 1 /bin/bash /app/update_filter_lists.sh" | crontab -
+# Install project dependencies
+RUN npm ci
 
-# Run the command on container startup
-ENTRYPOINT ["/usr/sbin/crond", "-l", "2", "-f"]
+# Run the entrypoint script on container startup
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -7,6 +7,7 @@ services:
     network_mode: bridge
     #tty:true # Only needed if you want crond logs in the docker log (noisy)
     environment:
+      TZ: "${TZ:-UTC}"
       CRON_SCHEDULE: "${CRON_SCHEDULE:-0 3 * * 1}"
       CLOUDFLARE_API_TOKEN: "${CLOUDFLARE_API_TOKEN}"
       CLOUDFLARE_ACCOUNT_ID: "${CLOUDFLARE_ACCOUNT_ID}"

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -5,6 +5,7 @@ services:
     image: ghcr.io/mrrfv/cloudflare-gateway-pihole-scripts:${IMAGE_TAG:-latest}
     restart: unless-stopped
     network_mode: bridge
+    tty:true
     environment:
       CRON_SCHEDULE: "${CRON_SCHEDULE:-0 3 * * 1}"
       CLOUDFLARE_API_TOKEN: "${CLOUDFLARE_API_TOKEN}"

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,0 +1,18 @@
+services:
+  cgps:
+    container_name: ${CONTAINER_NAME:-cgps}
+    hostname: ${CONTAINER_NAME:-cgps}
+    image: ghcr.io/mrrfv/cloudflare-gateway-pihole-scripts:${IMAGE_TAG:-latest}
+    restart: unless-stopped
+    network_mode: bridge
+    environment:
+      CLOUDFLARE_API_TOKEN: "${CLOUDFLARE_API_TOKEN}"
+      CLOUDFLARE_ACCOUNT_ID: "${CLOUDFLARE_ACCOUNT_ID}"
+      CLOUDFLARE_LIST_ITEM_LIMIT: "${CLOUDFLARE_LIST_ITEM_LIMIT:-300000}"
+      DRY_RUN: "${DRY_RUN:-0}"
+      BLOCK_PAGE_ENABLED: "${BLOCK_PAGE_ENABLED:-0}"
+      BLOCK_BASED_ON_SNI: "${BLOCK_BASED_ON_SNI:-0}"
+      ALLOWLIST_URLS: "${ALLOWLIST_URLS}"
+      BLOCKLIST_URLS: "${BLOCKLIST_URLS}"
+      #PING_URL: "${PING_URL}"
+      #DISCORD_WEBHOOK_URL: "${DISCORD_WEBHOOK_URL}"

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -5,7 +5,7 @@ services:
     image: ghcr.io/mrrfv/cloudflare-gateway-pihole-scripts:${IMAGE_TAG:-latest}
     restart: unless-stopped
     network_mode: bridge
-    tty:true
+    #tty:true # Only needed if you want crond logs in the docker log (noisy)
     environment:
       CRON_SCHEDULE: "${CRON_SCHEDULE:-0 3 * * 1}"
       CLOUDFLARE_API_TOKEN: "${CLOUDFLARE_API_TOKEN}"

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -6,6 +6,7 @@ services:
     restart: unless-stopped
     network_mode: bridge
     environment:
+      CRON_SCHEDULE: "${CRON_SCHEDULE:-0 3 * * 1}"
       CLOUDFLARE_API_TOKEN: "${CLOUDFLARE_API_TOKEN}"
       CLOUDFLARE_ACCOUNT_ID: "${CLOUDFLARE_ACCOUNT_ID}"
       CLOUDFLARE_LIST_ITEM_LIMIT: "${CLOUDFLARE_LIST_ITEM_LIMIT:-300000}"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,4 +4,5 @@
 echo "$CRON_SCHEDULE /usr/local/bin/npm start --prefix /app/" | crontab -
 
 # Start crond
+echo "Starting crond..."
 /usr/sbin/crond -l 2 -f

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Add cron entry
+echo "$CRON_SCHEDULE /bin/sh /app/update_filter_lists.sh" | crontab -
+
+# Start crond
+/usr/sbin/crond -l 2 -f

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Add cron entry
-echo "$CRON_SCHEDULE /bin/sh /app/update_filter_lists.sh" | crontab -
+echo "$CRON_SCHEDULE /usr/local/bin/npm start --prefix /app/" | crontab -
 
 # Start crond
 /usr/sbin/crond -l 2 -f

--- a/update_filter_lists.sh
+++ b/update_filter_lists.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+npm run download:allowlist
+npm run download:blocklist
+npm run cloudflare-delete
+npm run cloudflare-create

--- a/update_filter_lists.sh
+++ b/update_filter_lists.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-
+#!/bin/sh
+cd /app
 npm run download:allowlist
 npm run download:blocklist
 npm run cloudflare-delete

--- a/update_filter_lists.sh
+++ b/update_filter_lists.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-cd /app
-npm run download:allowlist
-npm run download:blocklist
-npm run cloudflare-delete
-npm run cloudflare-create


### PR DESCRIPTION
Added files, workflow, and examples to support running this locally in Docker instead of through GitHub actions.

The workflow currently requires creating a release on notable changes in order to trigger the image build on GHCR. Should you prefer that to occur on any commit, it can easily be modified to support that alternative workflow.

I've validated things work as expected for GHCR, though haven't yet had a successful run from a docker container while I wait for cron to trigger.

Resolves #58

UPDATE (2025-02-27 13:45):
- now supports push trigger on v* branches as well as release trigger on main
- includes support for setting time zone
- successfully ran as configured