### PR TITLE
Fix stripping of @@|| in allowlists

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -76,14 +76,13 @@ export const requestGateway = (path, options) =>
  * @returns {string}
  */
 export const normalizeDomain = (value, isAllowlisting) => {
-  const normalized = value
+  const init = (isAllowlisting) ? value.replace("@@||", "") : value;
+  const normalized = init
     .replace(/(0\.0\.0\.0|127\.0\.0\.1|::1|::)\s+/, "")
     .replace("||", "")
     .replace("^$important", "")
     .replace("*.", "")
     .replace("^", "");
-
-  if (isAllowlisting) return normalized.replace("@@||", "");
 
   return normalized;
 };


### PR DESCRIPTION
Addresses the issue described in this comment
https://github.com/mrrfv/cloudflare-gateway-pihole-scripts/pull/144#issuecomment-2811590521

Allowlist entries such as `@@||joinhoney.com^` are not properly normalized.
While it looks like `@@||` should be removed, it's not because the earlier `normalized` value has already removed the `||` so there's only the `@@` left.
By processing the longer match first, we can strip these as was intended.