### PR TITLE
Add script 'cloudflare-defragment'

### DIFF
--- a/cf_defragment.js
+++ b/cf_defragment.js
@@ -1,0 +1,42 @@
+import {
+  defragmentZeroTrustLists,
+  upsertZeroTrustDNSRule,
+  upsertZeroTrustSNIRule,
+  deleteZeroTrustListsOneByOne
+} from "./lib/api.js";
+import { BLOCK_BASED_ON_SNI } from "./lib/constants.js";
+import { notifyWebhook } from "./lib/utils.js";
+
+// Defragment the lists and rewrite the rules
+const { emptyLists, nonEmptyLists, stats } = await defragmentZeroTrustLists();
+
+
+// If we don't have any empty lists, there's no change to the rules
+if (emptyLists.length > 0) {
+  console.log('Updating rules...');
+  // We have any empty lists, first rewrite the rule(s) using the non-empty lists
+  await upsertZeroTrustDNSRule(nonEmptyLists, "CGPS Filter Lists");
+
+  // Optionally create a rule that matches the SNI.
+  // This only works for users who proxy their traffic through Cloudflare.
+  if (BLOCK_BASED_ON_SNI) {
+    await upsertZeroTrustSNIRule(nonEmptyLists, "CGPS Filter Lists - SNI Based Filtering");
+  }
+
+  // Now the lists are no longer referenced, we can delete them
+  console.log('Deleting empty lists...');
+  await deleteZeroTrustListsOneByOne(emptyLists);
+}
+
+// Print a summary of what we did
+console.log(`Defragmented ${stats.chunks} lists into ${stats.assignedLists} lists`);
+console.log(`Patches made to ${stats.patches} lists, moving ${stats.entriesToMove} entries`);
+
+// Continue summary if we deletes lists or rewrote rules
+if (emptyLists.length > 0) {
+  console.log(`Updated rules using ${stats.nonEmptyLists} lists`);
+  console.log(`Deleted ${stats.emptyLists} empty lists`);
+}
+
+// Send a notification to the webhook
+await notifyWebhook("CF Defragment script finished running");

--- a/cf_gateway_rule_create.js
+++ b/cf_gateway_rule_create.js
@@ -1,32 +1,16 @@
-import { getZeroTrustLists, upsertZeroTrustRule } from "./lib/api.js";
+import { getZeroTrustLists, upsertZeroTrustDNSRule, upsertZeroTrustSNIRule } from "./lib/api.js";
 import { BLOCK_BASED_ON_SNI } from "./lib/constants.js";
 import { notifyWebhook } from "./lib/utils.js";
 
 const { result: lists } = await getZeroTrustLists();
 
-// Create a Wirefilter expression to match DNS queries against all the lists
-const wirefilterDNSExpression = lists.reduce((previous, current) => {
-  if (!current.name.startsWith("CGPS List")) return previous;
-
-  return `${previous} any(dns.domains[*] in \$${current.id}) or `;
-}, "");
-
-console.log("Checking DNS rule...");
-// .slice removes the trailing ' or '
-await upsertZeroTrustRule(wirefilterDNSExpression.slice(0, -4), "CGPS Filter Lists", ["dns"]);
+// Upsert DNS rules for all lists
+await upsertZeroTrustDNSRule(lists, "CGPS Filter Lists");
 
 // Optionally create a rule that matches the SNI.
 // This only works for users who proxy their traffic through Cloudflare.
 if (BLOCK_BASED_ON_SNI) {
-  const wirefilterSNIExpression = lists.reduce((previous, current) => {
-    if (!current.name.startsWith("CGPS List")) return previous;
-
-    return `${previous} any(net.sni.domains[*] in \$${current.id}) or `;
-  }, "");
-
-  console.log("Creating SNI rule...");
-  // .slice removes the trailing ' or '
-  await upsertZeroTrustRule(wirefilterSNIExpression.slice(0, -4), "CGPS Filter Lists - SNI Based Filtering", ["l4"]);
+  await upsertZeroTrustSNIRule(lists, "CGPS Filter Lists - SNI Based Filtering");
 }
 
 // Send a notification to the webhook

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,8 @@
 import { BLOCK_PAGE_ENABLED, DEBUG, LIST_ITEM_SIZE } from "./constants.js";
 import { requestGateway } from "./helpers.js";
 
+const NOW_STR = new Date().toISOString();
+
 /**
  * Gets Zero Trust lists.
  *
@@ -123,11 +125,13 @@ export const synchronizeZeroTrustLists = async (items) => {
       // how many entries there were and how many we're removing.
       const spaceInList = LIST_ITEM_SIZE - (domainsByList[listId].length - patch.remove.length);
       // Take upto spaceInList entries from the additions into this list.
+      // Use the current timestamp as the description to track when we first see this domain.
+      // This can be used to defragment the lists later and consolidate more stable entries.
       const append = Array(spaceInList)
         .fill(0)
         .map(() => toAdd.shift())
         .filter(Boolean)
-        .map(domain => ({ value: domain }));
+        .map(domain => ({ value: domain, description: NOW_STR }));
       return [listId, { ...patch, append }];
     })
   );
@@ -144,7 +148,7 @@ export const synchronizeZeroTrustLists = async (items) => {
           .fill(0)
           .map(() => toAdd.shift())
           .filter(Boolean)
-          .map(domain => ({ value: domain }));
+          .map(domain => ({ value: domain, description: NOW_STR }));
 
         // Add this list edit to the patches
         if (append.length) {
@@ -171,6 +175,128 @@ export const synchronizeZeroTrustLists = async (items) => {
 };
 
 /**
+ * Defragment Zero Trust lists.
+ * Inspects existing lists starting with "CGPS List - Chunk <number>"
+ * Sorts the entries by the description which may include a timestamp.
+ * Unfortunately the API does not allow setting the created_at time for the entries.
+ * Rewrites the lists in order of the entry creation such that older
+ * domains are in the earlier lists. Older domains implies the domain is
+ * a more stable entry, so we're less likely to need to patch this list often.
+ * So we can reduce the number of lists we need to patch for updates and isolate
+ * the churn to the last list or few lists.
+ * @returns {Promise<Object>} A object that include the now empty and non-empty lists
+ */
+export const defragmentZeroTrustLists = async () => {
+  console.log("Checking existing lists...");
+  const { result: lists } = await getZeroTrustLists();
+  const cgpsLists = lists?.filter(({ name }) => name.startsWith("CGPS List - Chunk ")) || [];
+  console.log(`Found ${cgpsLists.length} existing lists. Downloading...`);
+
+  // Sort the lists by the natural number order in the name
+  cgpsLists.sort((a, b) => {
+    const aNum = parseInt(a.name.replace("CGPS List - Chunk ", ""));
+    const bNum = parseInt(b.name.replace("CGPS List - Chunk ", ""));
+    return aNum - bNum;
+  });
+
+  const allEntries = [];
+  // Fetch all the items in the lists
+  for (const list of cgpsLists) {
+    const { result: listItems } = await getZeroTrustListItems(list.id);
+    // Annotate the items with the list id that they came from so we know what to patch later
+    // Ensure the description is a valid timestamp, or set it to the current time.
+    // We use the description as the list addition time because the API does not allow setting the created_at time.
+    const itemsWithOriginListId = listItems?.map(item => ({
+      ...item,
+      originListId: list.id,
+      description: isNaN(new Date(item.description)) ? NOW_STR : item.description,
+    })) || [];
+    allEntries.push(...itemsWithOriginListId);
+  }
+
+  console.log(`Found ${allEntries.length} entries in ${cgpsLists.length} lists`);
+
+  // Sort the entries by the time stored in the description.
+  // For conflict resolution use the domain name as a tiebreaker.
+  // This is important to avoid flip-flopping entries between lists
+  // in subsequent runs.
+  allEntries.sort((a, b) => {
+    const createdAtA = new Date(a.description);
+    const createdAtB = new Date(b.description);
+    if (createdAtA.getTime() === createdAtB.getTime()) {
+      return a.value.localeCompare(b.value);
+    }
+    return createdAtA - createdAtB;
+  });
+
+  // Assign the entries to lists in order of the created_at time
+  const assignedEntries = allEntries.map((entry, index) => {
+    const listIndex = Math.floor(index / LIST_ITEM_SIZE);
+    const assignedListId = cgpsLists[listIndex]?.id || null;
+    // The list should always exist since we're only shuffling the entries
+    if (!assignedListId) {
+      throw new Error(`Unable to resolve list for entry ${index}, have only ${cgpsLists.length} lists`);
+    }
+    return { ...entry, assignedListId };
+  });
+
+  // Filter down to the entries that are changing assigned lists
+  const entriesToMove = assignedEntries.filter(entry => entry.originListId !== entry.assignedListId);
+
+  // Create the patches per list
+  const patches = {};
+  for (const entry of entriesToMove) {
+    const { originListId, assignedListId, ...gatewayItem } = entry;
+    if (!patches[originListId]) {
+      patches[originListId] = { append: [], remove: [] };
+    }
+    // Remove by value
+    patches[originListId].remove.push(gatewayItem.value);
+
+    if (!patches[assignedListId]) {
+      patches[assignedListId] = { append: [], remove: [] };
+    }
+    // Append by GatewayItem which has value, description and created_at properties
+    patches[assignedListId].append.push(gatewayItem);
+  }
+
+  console.log(`Found ${Object.keys(patches).length} patches to make, moving ${entriesToMove.length} entries...`);
+
+  // Process all the patches.
+  for(const [listId, patch] of Object.entries(patches)) {
+    const appends = !!patch.append ? patch.append.length : 0;
+    const removals = !!patch.remove ? patch.remove.length : 0;
+    console.log(`Updating list "${cgpsLists.find(list => list.id === listId).name}"${appends ? `, ${appends} additions` : ''}${removals ? `, ${removals} removals` : ''}`);
+    await patchExistingList(listId, patch);
+  }
+
+  // Did we leave any lists empty?
+  // We can tell by checking that the list ids are used in the assignedEntries
+  const assignedLists = new Set();
+  assignedEntries.forEach(entry => assignedLists.add(entry.assignedListId));
+  // Filter the lists down to those that are empty
+  const emptyLists = cgpsLists.filter(list => !assignedLists.has(list.id));
+  // Gather the non-empty lists, using the original list not just the chunked ones
+  // This is important to capture any manually created lists starting with "CGPS List"
+  // and not just the ones created by this script
+  const nonEmptyLists = lists.filter(list => !emptyLists.some(emptyList => emptyList.id === list.id));
+
+  return {
+    emptyLists,
+    nonEmptyLists,
+    stats: {
+      assignedLists: assignedLists.size,
+      emptyLists: emptyLists.length,
+      nonEmptyLists: nonEmptyLists.length,
+      entriesToMove: entriesToMove.length,
+      patches: Object.keys(patches).length,
+      allEntries: allEntries.length,
+      chunks: cgpsLists.length,
+    }
+  };
+}
+
+/**
  * Creates Zero Trust lists sequentially.
  * @param {string[]} items The domains.
  * @param {Number} [startingListNumber] The chunk number to start from when naming lists.
@@ -179,9 +305,10 @@ export const createZeroTrustListsOneByOne = async (items, startingListNumber = 1
   let totalListNumber = Math.ceil(items.length / LIST_ITEM_SIZE);
 
   for (let i = 0, listNumber = startingListNumber; i < items.length; i += LIST_ITEM_SIZE) {
+    // We use the description as the list addition time because the API does not allow setting the created_at time.
     const chunk = items
       .slice(i, i + LIST_ITEM_SIZE)
-      .map((item) => ({ value: item }));
+      .map((item) => ({ value: item, description: NOW_STR }));
     const listName = `CGPS List - Chunk ${listNumber}`;
 
     try {
@@ -342,4 +469,38 @@ export const deleteZeroTrustRule = async (id) => {
     console.error(`Error occurred while deleting rule - ${err.toString()}`);
     throw err;
   }
+};
+
+/**
+ * Creates or Updates Zero Trust DNS rule for a given array of lists.
+ * @param {object[]} lists The lists to be used for the rule.
+ * @param {string} lists[].id The ID of the list.
+ * @param {string} lists[].name The name of the list.
+ * @param {string} listName The name of the list.
+ */
+export const upsertZeroTrustDNSRule = async (lists, listName) => {
+  // Create a Wirefilter expression to match DNS queries against all the lists
+  const wirefilterDNSExpression = lists
+    .filter(({ name }) => name.startsWith("CGPS List"))
+    .map(({ id }) => `any(dns.domains[*] in \$${id})`)
+    .join(" or ");
+  console.log("Checking DNS rule...");
+  await upsertZeroTrustRule(wirefilterDNSExpression, listName, ["dns"]);
+};
+
+/**
+ * Creates or Updates Zero Trust SNI rule for a given array of lists.
+ * @param {object[]} lists The lists to be used for the rule.
+ * @param {string} lists[].id The ID of the list.
+ * @param {string} lists[].name The name of the list.
+ * @param {string} listName The name of the list.
+ */
+export const upsertZeroTrustSNIRule = async (lists, listName) => {
+  // Create a Wirefilter expression to match SNI queries against all the lists
+  const wirefilterSNIExpression = lists
+    .filter(({ name }) => name.startsWith("CGPS List"))
+    .map(({ id }) => `any(net.sni.domains[*] in \$${id})`)
+    .join(" or ");
+  console.log("Creating SNI rule...");
+  await upsertZeroTrustRule(wirefilterSNIExpression, listName, ["l4"]);
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "cloudflare-create:rule": "node cf_gateway_rule_create.js",
     "cloudflare-create:list": "node cf_list_create.js",
     "cloudflare-delete:rule": "node cf_gateway_rule_delete.js",
-    "cloudflare-delete:list": "node cf_list_delete.js"
+    "cloudflare-delete:list": "node cf_list_delete.js",
+    "cloudflare-defragment": "node cf_defragment.js"
   },
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Which consolidates domains into fewer lists, deleting any empty lists.
Domains are sorted by the time they were first added to one of our lists, by using a timestamp in the description field.
This is done so that more stable entries end up in the earlier lists and domains that come and go are in the later lists.
This enables the patching to be more efficient, touching only the later lists in most cases.

This feature is only useful if using the "refresh" mode to patch list files rather than delete/create each time.

Unfortunately the CF API does not allow specifying the created_at property while adding an entry to the list, so we use the description as a place to store this detail.