### PR TITLE
Fix 404 in recommended torrent-tracker allowlist URL (filename typo)

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -64,7 +64,7 @@ export const USER_DEFINED_BLOCKLIST_URLS = process.env.BLOCKLIST_URLS
 // You can have an unlimited number of allowlists, unlike blocklists.
 export const RECOMMENDED_ALLOWLIST_URLS = [
   // Torrent trackers
-  "https://raw.githubusercontent.com/im-sm/Pi-hole-Torrent-Blocklist/main/all-torrent-trackres.txt",
+  "https://raw.githubusercontent.com/im-sm/Pi-hole-Torrent-Blocklist/main/all-torrent-trackers.txt",
   // Banks
   "https://raw.githubusercontent.com/AdguardTeam/HttpsExclusions/master/exclusions/banks.txt",
   // Official Discord domains


### PR DESCRIPTION
The `RECOMMENDED_ALLOWLIST_URLS` entry for the torrent-tracker list has a filename typo (`all-torrent-trackres.txt`) and returns **HTTP 404**:

```
https://raw.githubusercontent.com/im-sm/Pi-hole-Torrent-Blocklist/main/all-torrent-trackres.txt   → 404
https://raw.githubusercontent.com/im-sm/Pi-hole-Torrent-Blocklist/main/all-torrent-trackers.txt   → 200
```

This corrects `trackres` → `trackers`.

Because `download_lists.js` downloads with plain `fetch` (which doesn't throw on 404), the current behaviour is that the `404: Not Found` body is appended to `allowlist.txt` and then dropped as an invalid domain — so the torrent-tracker allowlist is silently not applied.

Note: the source repo owner also renamed `im-sm` → `sakib-m`; the old path still resolves via GitHub's account-rename redirect, so only the filename needs fixing.

Fixes #249
