### PR TITLE
Defrag avoid cascade repack

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -177,13 +177,13 @@ export const synchronizeZeroTrustLists = async (items) => {
 /**
  * Defragment Zero Trust lists.
  * Inspects existing lists starting with "CGPS List - Chunk <number>"
- * Sorts the entries by the description which may include a timestamp.
- * Unfortunately the API does not allow setting the created_at time for the entries.
- * Rewrites the lists in order of the entry creation such that older
- * domains are in the earlier lists. Older domains implies the domain is
- * a more stable entry, so we're less likely to need to patch this list often.
- * So we can reduce the number of lists we need to patch for updates and isolate
- * the churn to the last list or few lists.
+ * Compacts them by pulling entries out of the back of the highest-numbered
+ * lists to fill any spare capacity in the lowest-numbered lists.
+ * This only touches lists that actually have spare capacity, or are being
+ * drained to fill one - a list that's already full is left completely alone.
+ * That keeps a single early removal from cascading into edits on every list
+ * that follows it: we don't require entries to sit in any particular global
+ * order, so filling a gap never requires reshuffling everything after it.
  * @returns {Promise<Object>} A object that include the now empty and non-empty lists
  */
 export const defragmentZeroTrustLists = async () => {
@@ -199,68 +199,69 @@ export const defragmentZeroTrustLists = async () => {
     return aNum - bNum;
   });
 
-  const allEntries = [];
-  // Fetch all the items in the lists
+  // Fetch all the items in the lists, keeping them grouped by the list they
+  // came from rather than merging into one big sorted sequence.
+  const entriesByList = new Map();
+  let allEntriesCount = 0;
   for (const list of cgpsLists) {
     const { result: listItems } = await getZeroTrustListItems(list.id);
-    // Annotate the items with the list id that they came from so we know what to patch later
     // Ensure the description is a valid timestamp, or set it to the current time.
     // We use the description as the list addition time because the API does not allow setting the created_at time.
-    const itemsWithOriginListId = listItems?.map(item => ({
-      ...item,
-      originListId: list.id,
+    const items = listItems?.map(item => ({
+      value: item.value,
       description: isNaN(new Date(item.description)) ? NOW_STR : item.description,
     })) || [];
-    allEntries.push(...itemsWithOriginListId);
+    entriesByList.set(list.id, items);
+    allEntriesCount += items.length;
   }
 
-  console.log(`Found ${allEntries.length} entries in ${cgpsLists.length} lists`);
+  console.log(`Found ${allEntriesCount} entries in ${cgpsLists.length} lists`);
 
-  // Sort the entries by the time stored in the description.
-  // For conflict resolution use the domain name as a tiebreaker.
-  // This is important to avoid flip-flopping entries between lists
-  // in subsequent runs.
-  allEntries.sort((a, b) => {
-    const createdAtA = new Date(a.description);
-    const createdAtB = new Date(b.description);
-    if (createdAtA.getTime() === createdAtB.getTime()) {
-      return a.value.localeCompare(b.value);
-    }
-    return createdAtA - createdAtB;
-  });
-
-  // Assign the entries to lists in order of the created_at time
-  const assignedEntries = allEntries.map((entry, index) => {
-    const listIndex = Math.floor(index / LIST_ITEM_SIZE);
-    const assignedListId = cgpsLists[listIndex]?.id || null;
-    // The list should always exist since we're only shuffling the entries
-    if (!assignedListId) {
-      throw new Error(`Unable to resolve list for entry ${index}, have only ${cgpsLists.length} lists`);
-    }
-    return { ...entry, assignedListId };
-  });
-
-  // Filter down to the entries that are changing assigned lists
-  const entriesToMove = assignedEntries.filter(entry => entry.originListId !== entry.assignedListId);
-
-  // Create the patches per list
+  // Compact in place: walk from the front looking for lists with spare
+  // capacity ("deficits"), and fill each one using entries pulled off the
+  // back of the highest-numbered lists that still have entries. A list keeps
+  // its number and its existing entries untouched unless it's the one being
+  // topped up or the one being drained.
   const patches = {};
-  for (const entry of entriesToMove) {
-    const { originListId, assignedListId, ...gatewayItem } = entry;
-    if (!patches[originListId]) {
-      patches[originListId] = { append: [], remove: [] };
-    }
-    // Remove by value
-    patches[originListId].remove.push(gatewayItem.value);
+  const getPatch = (listId) => {
+    if (!patches[listId]) patches[listId] = { append: [], remove: [] };
+    return patches[listId];
+  };
 
-    if (!patches[assignedListId]) {
-      patches[assignedListId] = { append: [], remove: [] };
+  let entriesMoved = 0;
+  let lowIndex = 0;
+  let highIndex = cgpsLists.length - 1;
+
+  while (lowIndex < highIndex) {
+    const lowList = cgpsLists[lowIndex];
+    const lowEntries = entriesByList.get(lowList.id);
+    const deficit = LIST_ITEM_SIZE - lowEntries.length;
+
+    if (deficit <= 0) {
+      lowIndex++;
+      continue;
     }
-    // Append by GatewayItem which has value, description and created_at properties
-    patches[assignedListId].append.push(gatewayItem);
+
+    const highList = cgpsLists[highIndex];
+    const highEntries = entriesByList.get(highList.id);
+
+    if (highEntries.length === 0) {
+      highIndex--;
+      continue;
+    }
+
+    const moveCount = Math.min(deficit, highEntries.length);
+    const moved = highEntries.splice(highEntries.length - moveCount, moveCount);
+    lowEntries.push(...moved);
+    entriesMoved += moveCount;
+
+    for (const entry of moved) {
+      getPatch(lowList.id).append.push(entry);
+      getPatch(highList.id).remove.push(entry.value);
+    }
   }
 
-  console.log(`Found ${Object.keys(patches).length} patches to make, moving ${entriesToMove.length} entries...`);
+  console.log(`Found ${Object.keys(patches).length} patches to make, moving ${entriesMoved} entries...`);
 
   // Process all the patches.
   for(const [listId, patch] of Object.entries(patches)) {
@@ -270,12 +271,8 @@ export const defragmentZeroTrustLists = async () => {
     await patchExistingList(listId, patch);
   }
 
-  // Did we leave any lists empty?
-  // We can tell by checking that the list ids are used in the assignedEntries
-  const assignedLists = new Set();
-  assignedEntries.forEach(entry => assignedLists.add(entry.assignedListId));
-  // Filter the lists down to those that are empty
-  const emptyLists = cgpsLists.filter(list => !assignedLists.has(list.id));
+  // Any lists left with no entries are now empty and can be deleted
+  const emptyLists = cgpsLists.filter(list => entriesByList.get(list.id).length === 0);
   // Gather the non-empty lists, using the original list not just the chunked ones
   // This is important to capture any manually created lists starting with "CGPS List"
   // and not just the ones created by this script
@@ -285,12 +282,12 @@ export const defragmentZeroTrustLists = async () => {
     emptyLists,
     nonEmptyLists,
     stats: {
-      assignedLists: assignedLists.size,
+      assignedLists: cgpsLists.length - emptyLists.length,
       emptyLists: emptyLists.length,
       nonEmptyLists: nonEmptyLists.length,
-      entriesToMove: entriesToMove.length,
+      entriesToMove: entriesMoved,
       patches: Object.keys(patches).length,
-      allEntries: allEntries.length,
+      allEntries: allEntriesCount,
       chunks: cgpsLists.length,
     }
   };

--- a/lib/api.js
+++ b/lib/api.js
@@ -263,12 +263,22 @@ export const defragmentZeroTrustLists = async () => {
 
   console.log(`Found ${Object.keys(patches).length} patches to make, moving ${entriesMoved} entries...`);
 
-  // Process all the patches.
-  for(const [listId, patch] of Object.entries(patches)) {
-    const appends = !!patch.append ? patch.append.length : 0;
-    const removals = !!patch.remove ? patch.remove.length : 0;
-    console.log(`Updating list "${cgpsLists.find(list => list.id === listId).name}"${appends ? `, ${appends} additions` : ''}${removals ? `, ${removals} removals` : ''}`);
-    await patchExistingList(listId, patch);
+  // Apply every addition before any removal. A list is only ever a source or
+  // a destination within a single compaction pass, never both, so doing all
+  // the appends first guarantees each moved entry is safely living in its new
+  // list before it's taken out of its old one - a domain blocked by two lists
+  // for a moment is harmless, but a domain blocked by neither is not.
+  for (const list of cgpsLists) {
+    const appends = patches[list.id]?.append;
+    if (!appends?.length) continue;
+    console.log(`Updating list "${list.name}", ${appends.length} additions`);
+    await patchExistingList(list.id, { append: appends });
+  }
+  for (const list of cgpsLists) {
+    const removals = patches[list.id]?.remove;
+    if (!removals?.length) continue;
+    console.log(`Updating list "${list.name}", ${removals.length} removals`);
+    await patchExistingList(list.id, { remove: removals });
   }
 
   // Any lists left with no entries are now empty and can be deleted


### PR DESCRIPTION
When running the defrag script, a removal of an "old" entry caused every subsequent chunk to get rewritten. This is unnecessary churn.

The assumption that a domain that has been in the list of a long time means that it's "stable" and less likely to be removed may be true. But these older entries do get removed sometimes. Given we previously tried to keep the entire list as a sorted set of full chunks, it means that a removal of an entry in any earlier chunk necessitates rewriting every following chunk in order to move 1 entry out to the prior chunk and pull 1 entry in from the next chunk.

With the goal of the defrag to be "use as few lists as possible", we don't need to keep the entire list in age order. We can simply fill any earlier gaps with entries from the last chunk, then delete any empty chunks from the end. The results is fewer edits, while keeping the chunks full. 


-- Original Description --
The previous defrag merged every entry into one array, sorted by age,
and reassigned each to position floor(i/1000). That forced strict
global repacking: a single removal near the front shifted every entry
after it, cascading patches through the entire chain of lists and
rewriting a late list's contents wholesale even though only a handful
of entries actually changed.

Replace it with a two-pointer compaction that fills spare capacity in
low-numbered lists using entries pulled from the back of high-numbered
lists. Only lists with an actual gap, or being drained to fill one,
are touched - a fully-packed list is left completely alone, so a
couple of stray removals no longer ripple through every list that
follows.